### PR TITLE
Fix messages to CentOS/7

### DIFF
--- a/tecmint_monitor.sh
+++ b/tecmint_monitor.sh
@@ -57,8 +57,8 @@ echo -e '\E[32m'"Operating System Type :" $tecreset $os
 
 # Check OS Release Version and Name
 cat /etc/os-release | grep 'NAME\|VERSION' | grep -v 'VERSION_ID' | grep -v 'PRETTY_NAME' > /tmp/osrelease
-echo -n -e '\E[32m'"OS Name :" $tecreset  && cat /tmp/osrelease | grep -v "VERSION" | cut -f2 -d\"
-echo -n -e '\E[32m'"OS Version :" $tecreset && cat /tmp/osrelease | grep -v "NAME" | cut -f2 -d\"
+echo -n -e '\E[32m'"OS Name :" $tecreset  && cat /tmp/osrelease | grep -v "VERSION" | grep -v CPE_NAME | cut -f2 -d\"
+echo -n -e '\E[32m'"OS Version :" $tecreset && cat /tmp/osrelease | grep -v "NAME" | grep -v CT_VERSION | cut -f2 -d\"
 
 # Check Architecture
 architecture=$(uname -m)


### PR DESCRIPTION
Now it shows CentOS/7 messages correctly:

```
Operating System Type :  GNU/Linux
OS Name : CentOS Linux
OS Version : 7 (Core)
Architecture :  x86_64
```
